### PR TITLE
Fix red screen due to window.postMessage override

### DIFF
--- a/src/react-native/hoc.js
+++ b/src/react-native/hoc.js
@@ -7,9 +7,28 @@ import { Events } from '../shared/constants';
 export const withMessaging = (WebView) => {
   return class WebViewWithMessaging extends React.PureComponent {
     render() {
+      const patchPostMessageFunction = () => {
+        var originalPostMessage = window.postMessage;
+        var patchedPostMessage = function(message, targetOrigin, transfer) {
+          originalPostMessage(message, targetOrigin, transfer);
+        };
+
+        patchedPostMessage.toString = () => {
+          return String(Object.hasOwnProperty).replace(
+            'hasOwnProperty',
+            'postMessage'
+          );
+        };
+        window.postMessage = patchedPostMessage;
+      };
+
+      const patchPostMessageJsCode =
+        '(' + String(patchPostMessageFunction) + ')();';
       return (
         <WebView
           {...this.props}
+          injectedJavaScript={patchPostMessageJsCode}
+          javaScriptEnabled={true}
           onMessage={this.handleWebViewMessage}
           ref={this.refWebView}
         />


### PR DESCRIPTION
This fixes #16 according to the fix given here https://github.com/facebook/react-native/issues/10865#issuecomment-269847703

**Important : in order to try this remember to launch the packager resetting its cache in order to be sure that the updated package gets in the bundle, so run it with:** 
`npm start -- --reset-cache`