### PR TITLE
Use new React Native Webview

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-native": "*"
   },
   "dependencies": {
-    "events": "^1.1.1"
+    "events": "^1.1.1",
+    "react-native-webview": "^10.9.1"
   }
 }

--- a/src/react-native/WebView.js
+++ b/src/react-native/WebView.js
@@ -1,4 +1,4 @@
-import { WebView as NativeWebView } from 'react-native';
+import { WebView as NativeWebView } from 'react-native-webview';
 import { withMessaging } from './hoc';
 
 export const WebView = withMessaging(NativeWebView);


### PR DESCRIPTION
The WebView from the react-native package has been moved to a separate package. It is recommended to use [react-native-webview](https://www.npmjs.com/package/react-native-webview) instead.

